### PR TITLE
Asteroid defuelification

### DIFF
--- a/data/human/human missions.txt
+++ b/data/human/human missions.txt
@@ -2026,7 +2026,6 @@ ship "Asteroid"
 	sprite "asteroid/medium rock/spin"
 		"frame rate" 10
 	attributes
-		"fuel capacity" 1
 		"hull" 10000
 		"mass" 1000
 		"drag" 10


### PR DESCRIPTION
Wyrdean on Discord reported that the asteroid in the Terraforming mission chain sometimes has ships attempting to refuel it. This just removes the fuel capacity from the asteroid.

I performed the first asteroid mission using an edited save file with fuel removed from the asteroid and it worked as normal.