### PR TITLE
Add Unfettered Wah Ki missions

### DIFF
--- a/data/hai/hai ships.txt
+++ b/data/hai/hai ships.txt
@@ -1390,6 +1390,30 @@ ship "Shield Beetle" "Shield Beetle (Tripulse Ionic Turret)"
 		`"Bufaer" Atomic Thruster`
 		"Pulse Rifle" 85
 
+ship "Shield Beetle" "Shield Beetle (Crew Destroyed)"
+	crew 30
+	add attributes
+		"bunks" -65
+	outfits
+		"Ion Cannon" 4
+		"Hai Tracker Pod" 4
+		"Hai Tracker" 120
+		"Tracker Storage Pod"
+		"Bullfrog Anti-Missile" 4
+		"Hai Octopus Jammer" 3
+		"Boulder Reactor"
+		"Geode Reactor"
+		"Hai Valley Batteries"
+		"Hai Diamond Regenerator"
+		"Hai Williwaw Cooling" 3
+		"Value Detector" 2
+		"Quantum Keystone"
+		"Pulse Rifle" 65
+		`"Bondir" Atomic Thruster`
+		`"Bufaer" Atomic Steering`
+		"Hyperdrive"
+		"Supercapacitor"
+
 
 
 # Flagship of the Unfettered Hai, filled with the spoils of wars against Korath and Wanderers:

--- a/data/hai/unfettered side missions.txt
+++ b/data/hai/unfettered side missions.txt
@@ -493,3 +493,132 @@ mission "Undeserved Anomalocaris"
 				take ship "Anomalocaris"
 			`	The leader of the Unfettered group then has a few of them escort you to the edge of the spaceport. On your way there, some of them seemed to be holding back some frustration, and you could have sworn one wanted to attack you at any moment. Eventually you are lead to a landed Lightning Bug, and after some messy paperwork, the Unfettered leave it with you.`
 				decline
+
+
+
+mission "Unfettered Sea Scorpion Shakedown"
+	autosave
+	name "Transport Unfettered Engineer"
+	description "Frusreep needs you to take her to Wah Ki to record some scans of the new Sea Scorpions in action."
+	minor
+	passengers 1
+	cargo 1
+	source
+		attributes "unfettered"
+	infiltrating
+	destination <origin> # Is this how you do this, so that the mission completes on return?
+	waypoint Wah Ki
+	to offer
+		has "Unfettered Jump Drive 1: done"
+		random < 40 # This will need adjusted.
+	on offer
+		conversation
+			`The spaceport is alive with the hustle and bustle of countless Hai, each going about their business and showing no sign of having noticed you other than the empty space which opens up around you wherever you go. Many of the Hai seem to be chittering away to themselves, the combined sound washing over you like white noise. You take a deep breath, savoring the spiced aroma which carries on the wind, then turn around to find a small Hai standing right at your heels who is literally bouncing on the spot.`
+			`	"Finally!" She says, rocking back on her feet a little to look up into your face. "I thought I would have to jump on your back to get your attention!"`
+			`	You take a moment to look over the newcomer, noticing her chipped front tooth and a spattering of small burn marks on her snout. Like most unfettered she is carrying a sidearm, but her holster is buttoned up and she doesn't appear to be threatening you.`
+				choice
+					`	"Well you have my attention now. How can I help you?"`
+						goto pitch
+					`	"Why didn't you just tug my elbow or something?"`
+			`	She visibly shudders, the motion starting at her snout and running down her body.`
+			`	"I didn't want to..." she trails off. "I mean, I have nothing against humans but you're so... bald."`
+			`	Before you have a chance to respond she covers her mouth with her hands and jumps back, her tail getting in the face of another passing Hai who looks mildly annoyed but keeps walking.`
+			`	"Can we start again?" She asks. "My name is Frusreep, I am an engineer working on the Sea Scorpion project and I would like to hire you for an easy job."`
+				choice
+					`	"I don't know."`
+					`	"'Easy', huh?"`
+					`	"Why didn't you say so? The <ship> is right this way."`
+						goto easy
+						
+			label pitch
+			`	"It's just a short mission," she says quickly. "No risk, a few days and its done. You know the Sea Scorpions? You must have seen them around, they're beautiful ships. Well, I helped design them. I don't mean that as a brag, I was just part of the team... Anyway, not important. I need to gather some data to see how they do in combat, so we can make some tweaks, you know? The thing is, it is hard to focus when there are a thousand trackers bearing down on you, so I thought it would be good to book passage with someone, you know, neutral."`
+			
+			label easy
+			`	"It's just me and some equipment, fly out to Wah Ki, give me some time to take my readings and then return here."`
+				choice
+					`"Okay, let's get going."`
+						accept
+					`"I don't think so. Find somebody else."`
+						decline
+						
+		log "Minor People" "Frusreep" `A chatty Unfettered engineer who works on the Sea Scorpion design team. She hired me to take her out to Wah Ki so she could scan some Sea Scorpions during a real battle.`
+						
+	on enter Wah Ki
+		conversation # Maybe insert a conditional part if you are flying a Sea Scorpion.
+			`Frusreep turns out to be pretty good company, chatting away amiably about any subject, but also happy to give you some space when you need it. She connects her equipment up to your scanners on the journey out, so that as soon as you emerge in Wah Ki she is ready to start recording.`
+			`	"So I just need to find a good candidate..." she says, scrolling down a list of ships faster than you can follow. "Here's one. Oh, it has a FL serial number, so it was built on our new line on Firelode! It'll be good to see if there's any variance in its engine output with the local flow valves!"`
+			`	One ship gets highlighted from the swarm, apparently already engaging in an attack run against a Geocoris, which is gunning its engines and attempting to angle away from the threat. Frusreep zooms in on the action just in time to see a volley of trackers launching, overwhelming the freighter's antimissile fire and slamming into their target.`
+			`	"Woohoo!" Frusreep yelps. "That's what we like to see!"`
+				choice
+					`"Isn't a scientist supposed to be impartial?"`
+					`"I thought you were tracking the performance of the ship, not the missiles."`
+						goto rebuke
+					`"Let me know when you have enough data."`
+						goto end
+			`	Frusreep twists in her chair to give you a nasty scowl.`
+			`	"Scientist?" She asks coldly. "Call me that again and you and I will be having a duel. I'm an engineer! And no, we don't need to be impartial."`
+				goto end
+			
+			label rebuke
+			`	Frusreep just shrugs the rebuke off.`
+			`	"I can multitask you know."`
+			
+			label end
+			`	You remain far outside the combat zone to avoid getting caught by a stray explosion as Frusreep tags one ship after another, feeding the data into her recording gear with practiced ease. For the twentieth time you watch her scrolling down the list of ships, but then she seems to freeze and the fur on the back of her neck stands on end.`
+			`	Looking closer at the screen, you see that she has tagged a Shield Beetle which seems to be in trouble. Its starboard steering thruster is out and it is careening fast into the atmosphere of <destination>.`
+			`	"What's wrong?" You ask, but Frusreep doesn't seem to hear you. You both watch as the Shield Beetle is wreathed in plasma as it dives uncontrolled into the atmosphere.`
+			`	"No," Frusreep whispers, her voice like the mewl of a distressed kitten. "It can't have been, I must have made a mistake."`
+			`	"Frusreep," you say louder. "What's going on?"`
+			`	She looks in the direction of your voice but you get the impression that she doesn't really see you. She seems suddenly more child-like. Afraid.`
+			`	"It's..." She takes a breath and regains some control. "I think that was my mother's ship. Wait, I need to check. I have to be sure."`
+			`	Tweaking the controls with incredible precision, she brings up her recording and highlights the name of the crashed vessel. Mon e Loh.`
+			`	"It's a common enough ship name," she says. "Maybe it's not..."`
+			`	She scrolls back through the recording until she finds the last time that the Mon e Loh anti-missile turrets fired, looping a tenth of a second of footage in ultra slow motion.`
+			`	"It's her alright," she says, sounding resigned now. "I helped install an extra set of supercapacitors to keep the Bullfrogs firing."`
+			`	She scrolls forward once again, watching the final moments as the Mon e Loh starts to tumble.`
+			`	"Wait," she says, peering closer and looping the video. "There. The starboard thrusters are firing. She must have fixed them!"`
+			`	She turns to you, hope glimmering in her eyes.`
+			`	"Captain, they might still be alive! Please... help me look for them."`
+				choice
+					`"That's not what you paid me for. We head back to <origin>."`
+					`"Are you sure?"`
+						goto agree
+					`"Of course. If there's any chance at all we'll find them."`
+						goto agree
+
+			
+			label sticktotheplan
+			`	Frusreep stares at you, her hand twitching near her weapon. For several long moments everything is still and then she seems to deflate.`
+			`	It's your ship, captain, she says dejectedly. If you're not brave enough to help I'll just need to find someone on <origin> who is.`
+				choice
+					`"That sounds like your best option."`
+						goto return
+					`"Well, okay then. I'll do it."`
+				
+			label agree
+			`	She nods once and looks back at her screen.`
+			`	"They would have come down somewhere around here," she says, indicating a point on the map which consists mostly of ocean. At least there won't be any locals around. Land on Cloudfire and I'll set up a search pattern."`
+				fail # Maybe this is not the best way to do this, I realised that there won't be an active mission again until the player lands on Cloudfire. Also, maybe there are other ways to fail the mission which I haven't thought of.
+			
+			label return
+			`	"If that's your decision I'll be in my cabin, Frusreep says, swishing past you on her way out."`
+			`	"A contract is a contract," you remind her as she goes, but she gives no indication of having heard you.`
+	
+	on complete
+		conversation
+			`	You land back on <origin>, and by the time you have finished your post-flight checklist Frusreep has gathered up her gear and is making her way out of the <ship>. She sees you watching her and turns away without a word.`
+		payment 50000 # Does this seem like a reasonable amount?
+
+
+
+mission "Unfettered Rescue"
+	autosave
+	name "Rescue the Mon e Loh"
+	description "Find and rescue the Mon e Loh, which crash-landed on <origin>."
+	source Cloudfire
+	landing
+	to offer
+		has "Unfettered Sea Scorpion Shakedown: failed"
+
+
+# To-do; add Shield Beetle 'Mon e Loh' with extra Supercapacitors.

--- a/data/hai/unfettered side missions.txt
+++ b/data/hai/unfettered side missions.txt
@@ -499,14 +499,13 @@ mission "Undeserved Anomalocaris"
 mission "Unfettered Sea Scorpion Shakedown"
 	autosave
 	name "Transport Unfettered Engineer"
-	description "Frusreep needs you to take her to Wah Ki to record some scans of the new Sea Scorpions in action."
+	description "Mera needs you to take her to Wah Ki to record some scans of the new Sea Scorpions in action."
 	minor
 	passengers 1
-	cargo 1 # Should this have a name, like 'Monitoring Gear'?
+	cargo 1
 	source
 		attributes "unfettered"
 	infiltrating
-	# destination <origin> Commenting this out for now because <origin> is wrong. How do you set up a mission which has a waypoint and then returns to the planet it was started on?
 	waypoint "Wah Ki"
 	to offer
 		has "Unfettered Jump Drive 1: done"
@@ -523,7 +522,7 @@ mission "Unfettered Sea Scorpion Shakedown"
 			`	She visibly shudders, the motion starting at her snout and running down her body.`
 			`	"I didn't want to..." she trails off. "I mean, I have nothing against humans but you're so... bald."`
 			`	Before you have a chance to respond she covers her mouth with her hands and jumps back, her tail getting in the face of another passing Hai who looks mildly annoyed but keeps walking.`
-			`	"Can we start again?" She asks. "My name is Frusreep, I am an engineer working on the Sea Scorpion project and I would like to hire you for an easy job."`
+			`	"Can we start again?" She asks. "My name is Mera, I am an engineer working on the Sea Scorpion project and I would like to hire you for an easy job."`
 				choice
 					`	"I don't know."`
 					`	"'Easy', huh?"`
@@ -541,34 +540,34 @@ mission "Unfettered Sea Scorpion Shakedown"
 					`"I don't think so. Find somebody else."`
 						decline
 						
-		log "Minor People" "Frusreep" `A chatty Unfettered engineer who works on the Sea Scorpion design team. She hired me to take her out to Wah Ki so she could scan some Sea Scorpions during a real battle.`
+		log "People" "Mera" `An Unfettered engineer who is interested in ship designs of all kinds. She is easily excited by new technologies and ships, and seems to communicate partly through her body language.`
 						
 	on enter Wah Ki
 		conversation # Maybe insert a conditional part if you are flying a Sea Scorpion.
-			`Frusreep turns out to be pretty good company, chatting away amiably about any subject, but also happy to give you some space when you need it. She connects her equipment up to your scanners on the journey out, so that as soon as you emerge in Wah Ki she is ready to start recording.`
+			`Mera turns out to be pretty good company, chatting away amiably about any subject, but also happy to give you some space when you need it. She connects her equipment up to your scanners on the journey out, so that as soon as you emerge in Wah Ki she is ready to start recording.`
 			`	"So I just need to find a good candidate..." she says, scrolling down a list of ships faster than you can follow. "Here's one. Oh, it has a FL serial number, so it was built on our new line on Firelode! It'll be good to see if there's any variance in its engine output with the local flow valves!"`
-			`	One ship gets highlighted from the swarm, apparently already engaging in an attack run against a Geocoris, which is gunning its engines and attempting to angle away from the threat. Frusreep zooms in on the action just in time to see a volley of trackers launching, overwhelming the freighter's antimissile fire and slamming into their target.`
-			`	"Woohoo!" Frusreep yelps. "That's what we like to see!"`
+			`	One ship gets highlighted from the swarm, apparently already engaging in an attack run against a Geocoris, which is gunning its engines and attempting to angle away from the threat. Mera zooms in on the action just in time to see a volley of trackers launching, overwhelming the freighter's antimissile fire and slamming into their target.`
+			`	"Woohoo!" Mera yelps. "That's what we like to see!"`
 				choice
 					`"Isn't a scientist supposed to be impartial?"`
 					`"I thought you were tracking the performance of the ship, not the missiles."`
 						goto rebuke
 					`"Let me know when you have enough data."`
 						goto end
-			`	Frusreep twists in her chair to give you a nasty scowl.`
+			`	Mera twists in her chair to give you a nasty scowl.`
 			`	"Scientist?" She asks coldly. "Call me that again and you and I will be having a duel. I'm an engineer! And no, we don't need to be impartial."`
 				goto end
 			
 			label rebuke
-			`	Frusreep just shrugs the rebuke off.`
+			`	Mera just shrugs the rebuke off.`
 			`	"I can multitask you know."`
 			
 			label end
-			`	You remain far outside the combat zone to avoid getting caught by a stray explosion as Frusreep tags one ship after another, feeding the data into her recording gear with practiced ease. For the twentieth time you watch her scrolling down the list of ships, but then she seems to freeze and the fur on the back of her neck stands on end.`
+			`	You remain far outside the combat zone to avoid getting caught by a stray explosion as Mera tags one ship after another, feeding the data into her recording gear with practiced ease. For the twentieth time you watch her scrolling down the list of ships, but then she seems to freeze and the fur on the back of her neck stands on end.`
 			`	Looking closer at the screen, you see that she has tagged a Shield Beetle which seems to be in trouble. Its starboard steering thruster is out and it is careening fast into the atmosphere of <destination>.`
-			`	"What's wrong?" You ask, but Frusreep doesn't seem to hear you. You both watch as the Shield Beetle is wreathed in plasma as it dives uncontrolled into the atmosphere.`
-			`	"No," Frusreep whispers, her voice like the mewl of a distressed kitten. "It can't have been, I must have made a mistake."`
-			`	"Frusreep," you say louder. "What's going on?"`
+			`	"What's wrong?" You ask, but Mera doesn't seem to hear you. You both watch as the Shield Beetle is wreathed in plasma as it dives uncontrolled into the atmosphere.`
+			`	"No," Mera whispers, her voice like the mewl of a distressed kitten. "It can't have been, I must have made a mistake."`
+			`	"Mera," you say louder. "What's going on?"`
 			`	She looks in the direction of your voice but you get the impression that she doesn't really see you. She seems suddenly more child-like. Afraid.`
 			`	"It's..." She takes a breath and regains some control. "I think that was my mother's ship. Wait, I need to check. I have to be sure."`
 			`	Tweaking the controls with incredible precision, she brings up her recording and highlights the name of the crashed vessel. Mon e Loh.`
@@ -588,7 +587,7 @@ mission "Unfettered Sea Scorpion Shakedown"
 
 			
 			label sticktotheplan
-			`	Frusreep stares at you, her hand twitching near her weapon. For several long moments everything is still and then she seems to deflate.`
+			`	Mera stares at you, her hand twitching near her weapon. For several long moments everything is still and then she seems to deflate.`
 			`	It's your ship, captain, she says dejectedly. If you're not brave enough to help I'll just need to find someone on <origin> who is.`
 				choice
 					`"That sounds like your best option."`
@@ -598,17 +597,25 @@ mission "Unfettered Sea Scorpion Shakedown"
 			label agree
 			`	She nods once and looks back at her screen.`
 			`	"They would have come down somewhere around here," she says, indicating a point on the map which consists mostly of ocean. At least there won't be any locals around. Land on Cloudfire and I'll set up a search pattern."`
-				fail # Maybe this is not the best way to do this, I realized that there won't be an active mission again until the player lands on Cloudfire. Also, maybe there are other ways to fail the mission which I haven't thought of.
 			
 			label return
-			`	"If that's your decision I'll be in my cabin, Frusreep says, swishing past you on her way out."`
+			`	"If that's your decision I'll be in my cabin, Mera says, swishing past you on her way out."`
 			`	"A contract is a contract," you remind her as she goes, but she gives no indication of having heard you.`
+				set "refused rescue"
 	
 	on complete
 		conversation
-			`	You land back on <origin>, and by the time you have finished your post-flight checklist Frusreep has gathered up her gear and is making her way out of the <ship>. She sees you watching her and turns away without a word.`
-		payment 50000 # Does this seem like a reasonable amount?
-
+			branch refused
+				"refused rescue" = 1
+			
+			# Branch to fire when completing mission after completion of Unfettered Rescue.
+			
+			label refused
+			`	You land back on <origin>, and by the time you have finished your post-flight checklist Mera has gathered up her gear and is making her way out of the <ship>. She sees you watching her and turns away without a word.`
+			action
+				payment 50000 # Does this seem like a reasonable amount?
+				clear "refused rescue"
+			
 
 
 mission "Unfettered Rescue"
@@ -618,7 +625,11 @@ mission "Unfettered Rescue"
 	source Cloudfire
 	landing
 	to offer
-		has "Unfettered Sea Scorpion Shakedown: failed"
+		has "Unfettered Sea Scorpion Shakedown: active"
+
+
+
+
 
 
 # To-do; add Shield Beetle 'Mon e Loh' with extra Supercapacitors.

--- a/data/hai/unfettered side missions.txt
+++ b/data/hai/unfettered side missions.txt
@@ -626,7 +626,21 @@ mission "Unfettered Rescue"
 	landing
 	to offer
 		has "Unfettered Sea Scorpion Shakedown: active"
-
+	on offer
+		conversation
+			`You descend into the atmosphere of <source>, Mera navigating as she tries to reconstruct the flightpath of the Mon e Loh. Night is falling, which you think should hamper your search efforts, but Mera is upbeat.`
+			`	"No, this is good," she insists, "lower temperature, much less ambient radiation, it should make any trail they left stand out better."`
+			`	Mera directs you into a long, wide loop, skirting the section of ocean which she had earlier determined to be the most likely area for the Shield Beetle to have come down. The low hum of your engines is the only sound as you follow the course, and outside the clouds fade from bright white, through orange to a delicate pink.`
+			`	"Nothing so far," Mera grumbles, and you see that she is tightly gripping the sides of her display.`
+			choice
+				`	We'll keep looking. We'll find them.`
+				`	Maybe we should try a different strategy?`
+			`	Mera is silent but her grip loosens a little and then she looks up from her screen in thought.`
+			`	"We know they had propulsion," she muses, "so they wouldn't have just kept falling. They would aim for land."`
+			`	She pulls up the map again, this time examining the nearby islands, zooming in and out as she examines each in turn.`
+			`	"Somewhere with fresh water, no local population, and maybe a sheltered bay to splash down in."`
+			`	After a few moments she identifies one and passes the bearing over to your helm. You swing the <ship> around onto the new course, gun the engines, and soon you can see the island breaking up the horizon dead ahead. As you draw closer you see two peaks covered in greenery jutting out of the ocean, with a wide sand bank in the middle which probably splits the island in two at high tide.`
+			`	You circle the island, which looks idyllically picturesque in the dwindiling twilight, but there is no sign of the Mon e Loh.`
 
 
 

--- a/data/hai/unfettered side missions.txt
+++ b/data/hai/unfettered side missions.txt
@@ -502,12 +502,12 @@ mission "Unfettered Sea Scorpion Shakedown"
 	description "Frusreep needs you to take her to Wah Ki to record some scans of the new Sea Scorpions in action."
 	minor
 	passengers 1
-	cargo 1
+	cargo 1 # Should this have a name, like 'Monitoring Gear'?
 	source
 		attributes "unfettered"
 	infiltrating
-	destination <origin> # Is this how you do this, so that the mission completes on return?
-	waypoint Wah Ki
+	# destination <origin> Commenting this out for now because <origin> is wrong. How do you set up a mission which has a waypoint and then returns to the planet it was started on?
+	waypoint "Wah Ki"
 	to offer
 		has "Unfettered Jump Drive 1: done"
 		random < 40 # This will need adjusted.

--- a/data/hai/unfettered side missions.txt
+++ b/data/hai/unfettered side missions.txt
@@ -598,7 +598,7 @@ mission "Unfettered Sea Scorpion Shakedown"
 			label agree
 			`	She nods once and looks back at her screen.`
 			`	"They would have come down somewhere around here," she says, indicating a point on the map which consists mostly of ocean. At least there won't be any locals around. Land on Cloudfire and I'll set up a search pattern."`
-				fail # Maybe this is not the best way to do this, I realised that there won't be an active mission again until the player lands on Cloudfire. Also, maybe there are other ways to fail the mission which I haven't thought of.
+				fail # Maybe this is not the best way to do this, I realized that there won't be an active mission again until the player lands on Cloudfire. Also, maybe there are other ways to fail the mission which I haven't thought of.
 			
 			label return
 			`	"If that's your decision I'll be in my cabin, Frusreep says, swishing past you on her way out."`

--- a/data/hai/unfettered side missions.txt
+++ b/data/hai/unfettered side missions.txt
@@ -505,7 +505,6 @@ mission "Unfettered Sea Scorpion Shakedown"
 	cargo 1
 	source
 		attributes "unfettered"
-	infiltrating
 	waypoint "Wah Ki"
 	to offer
 		has "Unfettered Jump Drive 1: done"
@@ -571,43 +570,44 @@ mission "Unfettered Sea Scorpion Shakedown"
 
 		timer 600
 			on timeup
-				`	You remain far outside the combat zone to avoid getting caught by a stray explosion as Mera tags one ship after another, feeding the data into her recording gear with practiced ease. For the twentieth time you watch her scrolling down the list of ships, but then she seems to freeze and the fur on the back of her neck stands on end.`
-				`	Looking closer at the screen, you see that she has tagged a Shield Beetle which seems to be in trouble. Its starboard steering thruster is out and it is careening fast into the atmosphere of Cloudfire.`
-				`	"What's wrong?" You ask, but Mera doesn't seem to hear you. You both watch as the Shield Beetle is wreathed in plasma as it dives uncontrolled into the atmosphere.`
-				`	"No," Mera whispers, her voice like the mewl of a distressed kitten. "It can't have been, I must have made a mistake."`
-				`	"Mera," you say louder. "What's going on?"`
-				`	She looks in the direction of your voice but you get the impression that she doesn't really see you. She seems suddenly more child-like. Afraid.`
-				`	"It's..." She takes a breath and regains some control. "I think that was my mother's ship. Wait, I need to check. I have to be sure."`
-				`	Tweaking the controls with incredible precision, she brings up her recording and highlights the name of the crashed vessel. Mon e Loh.`
-				`	"It's a common enough ship name," she says. "Maybe it's not..."`
-				`	She scrolls back through the recording until she finds the last time that the Mon e Loh anti-missile turrets fired, looping a tenth of a second of footage in ultra slow motion.`
-				`	"It's her alright," she says, sounding resigned now. "I helped install an extra set of supercapacitors to keep the Bullfrogs firing."`
-				`	She scrolls forward once again, watching the final moments as the Mon e Loh starts to tumble.`
-				`	"Wait," she says, peering closer and looping the video. "There. The starboard thrusters are firing. She must have fixed them!"`
-				`	She turns to you, hope glimmering in her eyes.`
-				`	"Captain, they might still be alive! Please... help me look for them."`
-					choice
-						`"That's not what you're paying me for. We head back to <origin>."`
-						`"Are you sure?"`
-							goto agree
-						`"Of course. If there's any chance at all we'll find them."`
-							goto agree
+				conversation
+					`You remain far outside the combat zone to avoid getting caught by a stray explosion as Mera tags one ship after another, feeding the data into her recording gear with practiced ease. For the twentieth time you watch her scrolling down the list of ships, but then she seems to freeze and the fur on the back of her neck stands on end.`
+					`	Looking closer at the screen, you see that she has tagged a Shield Beetle which seems to be in trouble. Its starboard steering thruster is out and it is careening fast into the atmosphere of Cloudfire.`
+					`	"What's wrong?" You ask, but Mera doesn't seem to hear you. You both watch as the Shield Beetle is wreathed in plasma as it dives uncontrolled into the atmosphere.`
+					`	"No," Mera whispers, her voice like the mewl of a distressed kitten. "It can't have been, I must have made a mistake."`
+					`	"Mera," you say louder. "What's going on?"`
+					`	She looks in the direction of your voice but you get the impression that she doesn't really see you. She seems suddenly more child-like. Afraid.`
+					`	"It's..." She takes a breath and regains some control. "I think that was my mother's ship. Wait, I need to check. I have to be sure."`
+					`	Tweaking the controls with incredible precision, she brings up her recording and highlights the name of the crashed vessel. Mon e Loh.`
+					`	"It's a common enough ship name," she says. "Maybe it's not..."`
+					`	She scrolls back through the recording until she finds the last time that the Mon e Loh anti-missile turrets fired, looping a tenth of a second of footage in ultra slow motion.`
+					`	"It's her alright," she says, sounding resigned now. "I helped install an extra set of supercapacitors to keep the Bullfrogs firing."`
+					`	She scrolls forward once again, watching the final moments as the Mon e Loh starts to tumble.`
+					`	"Wait," she says, peering closer and looping the video. "There. The starboard thrusters are firing. She must have fixed them!"`
+					`	She turns to you, hope glimmering in her eyes.`
+					`	"Captain, they might still be alive! Please... help me look for them."`
+						choice
+							`"That's not what you're paying me for. We head back to <origin>."`
+							`"Are you sure?"`
+								goto agree
+							`"Of course. If there's any chance at all we'll find them."`
+								goto agree
 
-				`	Mera stares at you, her hand twitching near her weapon. For several long moments everything is still and then she seems to deflate.`
-				`	"It's your ship, captain," she says dejectedly. "If you're not brave enough to help I'll just need to find someone on <origin> who is."`
-					choice
-						`"That sounds like your best option."`
-							goto return
-						`"Well, okay then. I'll do it."`
+					`	Mera stares at you, her hand twitching near her weapon. For several long moments everything is still and then she seems to deflate.`
+					`	"It's your ship, captain," she says dejectedly. "If you're not brave enough to help I'll just need to find someone on <origin> who is."`
+						choice
+							`"That sounds like your best option."`
+								goto return
+							`"Well, okay then. I'll do it."`
 
-				label agree
-				`	She nods once and looks back at her screen.`
-				`	"They would have come down somewhere around here," she says, indicating a point on the map which consists mostly of ocean. At least there won't be any locals around. Land on Cloudfire and I'll set up a search pattern."`
+					label agree
+					`	She nods once and looks back at her screen.`
+					`	"They would have come down somewhere around here," she says, indicating a point on the map which consists mostly of ocean. At least there won't be any locals around. Land on Cloudfire and I'll set up a search pattern."`
 
-				label return
-				`	"If that's your decision I'll be in my cabin," Mera says, swishing past you on her way out.`
-				`	"A contract is a contract," you remind her as she goes, but she gives no indication of having heard you.`
-					set "refused rescue"
+					label return
+					`	"If that's your decision I'll be in my cabin," Mera says, swishing past you on her way out.`
+					`	"A contract is a contract," you remind her as she goes, but she gives no indication of having heard you.`
+						set "refused rescue"
 
 	to complete
 		or
@@ -619,7 +619,7 @@ mission "Unfettered Sea Scorpion Shakedown"
 			`You have landed back on <origin> after promising Mera that you would help to find the Mon e Loh, but you have not found the ship yet. Return to Cloudfire to search for survivors.`
 
 	on complete
-		conversation
+		conversation # This seems a bit short to be a conversation but I don't think you can use branches in dialog?
 			branch refused
 				"refused rescue" = 1
 				`	You land back on <origin>, and by the time you have finished your post-flight checklist Mera has disconnected her gear and is making her way out of the <ship>. She sees you watching her and turns away without a word.`
@@ -632,7 +632,7 @@ mission "Unfettered Sea Scorpion Shakedown"
 				# Branch to fire when completing mission after completion of Unfettered Rescue. In this branch Mera will let you keep the value detector and the captain of the Mon e Loh will give you something extra. I'll write this after the rescue mission.
 
 	npc accompany
-		government "Hai (Unfettered)" # I'll neeed to switch this to something neutral, I think.
+		government "Hai (Unfettered Civilians)"
 		personality landing
 		ship "Shield Beetle (Low crew)" "Mon e Loh"
 		system "Wah Ki"
@@ -645,6 +645,7 @@ mission "Unfettered Rescue"
 	description "Find and rescue the Mon e Loh, which crash-landed on <origin>."
 	source Cloudfire
 	landing
+	infiltrating
 	to offer
 		has "Unfettered Sea Scorpion Shakedown: active"
 	on offer
@@ -661,7 +662,7 @@ mission "Unfettered Rescue"
 			`	She pulls up the map again, this time examining the nearby islands, zooming in and out as she examines each in turn.`
 			`	"Somewhere with fresh water, no local population, and maybe a sheltered bay to splash down in."`
 			`	After a few moments she identifies one and passes the bearing over to your helm. You swing the <ship> around onto the new course, gun the engines, and soon you can see the island breaking up the horizon dead ahead. As you draw closer you see two peaks covered in greenery jutting out of the ocean, with a wide sand bank in the middle which probably splits the island in two at high tide.`
-			`	You circle the island, which looks idyllically picturesque in the dwindiling twilight, but there is no sign of the Mon e Loh. Mera's frustration is evident by the way she taps her claws against the side of her console, the rhythm getting ever quicker. Suddenly she stops.`
+			`	You circle the island, which looks idyllically picturesque in the dwindiling twilight, but there is no sign of the Mon e Loh. Mera's taps her claws against the side of her console, the tempo rising along with her frustration. Suddenly she stops.`
 			`	"They're hiding," she says, throwing her head back and spinning her chair in a full circle. "They don't want the Fettered to find them like this!"`
 			choice
 				`	"So how does this help us?"`
@@ -669,4 +670,16 @@ mission "Unfettered Rescue"
 			`	"It's simple," Mera tells you with a playful glint in her eye. "I'll just call my mom."`
 			`	She pulls out a standard communicator and taps it a few times.`
 			`	"What?" she asks you with a smirk. "You thought I was going to remodulate your shield matrix or spoof your IFF? Sometimes the simplest solutions are the best."`
-			`	Ten minutes later, after listening in to a surreal conversation in which Mera and her mother organized a rendezvous as though they were arranging to meet at a cozy tea house instead of an extraction from behind enemy lines, the <ship> lands on the beach of the island you had circled earlier, while the Mon e Loh rises from the bay like a leviathan.`
+			`	Ten minutes later, after listening in to a surreal conversation in which Mera and her mother organize a rendezvous as though they are arranging a meeting at a cozy tea house instead of a rescue mission behind enemy lines, the <ship> lands on the beach of the island you had circled earlier, while the Mon e Loh rises from the bay like a leviathan.`
+			`	Mera, toting a bag of tools and some spare parts she found lying around, marches straight in to the belly of the shield beetle, bustling past some walking wounded Hai who come out to set up a camp on the beach. You chip in, collecting firewood and supplementing their provisions with some of your own, and soon enough you are enjoying the warm breeze over the gently lapping waves, and trying to pick out the stars that you have visited from amongst the myriad sparkling in the sky above., although the effect is somewhat ruined by the loud bangs sporadically echoing out of the Mon e Loh.`
+			`	"Captain <last>?"`
+			`	The voice startles you out of a reverie and you turn to see a venerable Hai with crooked whiskers and silver-grey streaks in his fur. He wears an ornate uniform which, by way of various ribbons and medals, leaves no doubt in your mind that its wearer has seen more than most and is deserving of respect, if not adulation.`
+			choice
+				`	"That's me."`
+				`	"At your service, sir."`
+				`	"Who's asking?"`
+			`	He nods gravely, as though you have just confirmed his worst fears.`
+			`	"I am Captain Pripiam of the Mon e Loh. I wanted to thank you personally for your assistance."`
+			choice
+				`	"I'm just glad I could help."`
+				`	"

--- a/data/hai/unfettered side missions.txt
+++ b/data/hai/unfettered side missions.txt
@@ -511,6 +511,7 @@ mission "Unfettered Sea Scorpion Shakedown"
 		has "Unfettered Jump Drive 1: done"
 		random < 40 # This will need adjusted.
 	on offer
+		outfit "value detector" 1
 		conversation
 			`The spaceport is alive with the hustle and bustle of countless Hai, each going about their business and showing no sign of having noticed you other than the empty space which opens up around you wherever you go. Many of the Hai seem to be chittering away to themselves, the combined sound washing over you like white noise. You take a deep breath, savoring the spiced aroma which carries on the wind, then turn around to find a small Hai standing right at your heels who is literally bouncing on the spot.`
 			`	"Finally!" She says, rocking back on her feet a little to look up into your face. "I thought I would have to jump on your back to get your attention!"`
@@ -528,24 +529,28 @@ mission "Unfettered Sea Scorpion Shakedown"
 					`	"'Easy', huh?"`
 					`	"Why didn't you say so? The <ship> is right this way."`
 						goto easy
-						
+
 			label pitch
 			`	"It's just a short mission," she says quickly. "No risk, a few days and its done. You know the Sea Scorpions? You must have seen them around, they're beautiful ships. Well, I helped design them. I don't mean that as a brag, I was just part of the team... Anyway, not important. I need to gather some data to see how they do in combat, so we can make some tweaks, you know? The thing is, it is hard to focus when there are a thousand trackers bearing down on you, so I thought it would be good to book passage with someone, you know, neutral."`
-			
+
 			label easy
 			`	"It's just me and some equipment, fly out to Wah Ki, give me some time to take my readings and then return here."`
 				choice
 					`"Okay, let's get going."`
-						accept
+						goto okay
 					`"I don't think so. Find somebody else."`
 						decline
-						
+
+			label okay
+			`	She literally jumps up and down on the spot and then turns to hustle towards the <ship>, calling over her shoulder, "I'll install the equipment as we go, it shouldn't be difficult."`
+			accept
+			
 		log "People" "Mera" `An Unfettered engineer who is interested in ship designs of all kinds. She is easily excited by new technologies and ships, and seems to communicate partly through her body language.`
-						
+
 	on enter Wah Ki
 		conversation # Maybe insert a conditional part if you are flying a Sea Scorpion.
 			`Mera turns out to be pretty good company, chatting away amiably about any subject, but also happy to give you some space when you need it. She connects her equipment up to your scanners on the journey out, so that as soon as you emerge in Wah Ki she is ready to start recording.`
-			`	"So I just need to find a good candidate..." she says, scrolling down a list of ships faster than you can follow. "Here's one. Oh, it has a FL serial number, so it was built on our new line on Firelode! It'll be good to see if there's any variance in its engine output with the local flow valves!"`
+			`	"I just need to find a good candidate..." she says, scrolling down a list of ships faster than you can follow. "Here's one. Oh, it has a FL serial number, so it was built on our new line on Firelode! It'll be good to see if there's any variance in its engine output with the local flow valves!"`
 			`	One ship gets highlighted from the swarm, apparently already engaging in an attack run against a Geocoris, which is gunning its engines and attempting to angle away from the threat. Mera zooms in on the action just in time to see a volley of trackers launching, overwhelming the freighter's antimissile fire and slamming into their target.`
 			`	"Woohoo!" Mera yelps. "That's what we like to see!"`
 				choice
@@ -557,65 +562,81 @@ mission "Unfettered Sea Scorpion Shakedown"
 			`	Mera twists in her chair to give you a nasty scowl.`
 			`	"Scientist?" She asks coldly. "Call me that again and you and I will be having a duel. I'm an engineer! And no, we don't need to be impartial."`
 				goto end
-			
+
 			label rebuke
 			`	Mera just shrugs the rebuke off.`
 			`	"I can multitask you know."`
-			
-			label end
-			`	You remain far outside the combat zone to avoid getting caught by a stray explosion as Mera tags one ship after another, feeding the data into her recording gear with practiced ease. For the twentieth time you watch her scrolling down the list of ships, but then she seems to freeze and the fur on the back of her neck stands on end.`
-			`	Looking closer at the screen, you see that she has tagged a Shield Beetle which seems to be in trouble. Its starboard steering thruster is out and it is careening fast into the atmosphere of <destination>.`
-			`	"What's wrong?" You ask, but Mera doesn't seem to hear you. You both watch as the Shield Beetle is wreathed in plasma as it dives uncontrolled into the atmosphere.`
-			`	"No," Mera whispers, her voice like the mewl of a distressed kitten. "It can't have been, I must have made a mistake."`
-			`	"Mera," you say louder. "What's going on?"`
-			`	She looks in the direction of your voice but you get the impression that she doesn't really see you. She seems suddenly more child-like. Afraid.`
-			`	"It's..." She takes a breath and regains some control. "I think that was my mother's ship. Wait, I need to check. I have to be sure."`
-			`	Tweaking the controls with incredible precision, she brings up her recording and highlights the name of the crashed vessel. Mon e Loh.`
-			`	"It's a common enough ship name," she says. "Maybe it's not..."`
-			`	She scrolls back through the recording until she finds the last time that the Mon e Loh anti-missile turrets fired, looping a tenth of a second of footage in ultra slow motion.`
-			`	"It's her alright," she says, sounding resigned now. "I helped install an extra set of supercapacitors to keep the Bullfrogs firing."`
-			`	She scrolls forward once again, watching the final moments as the Mon e Loh starts to tumble.`
-			`	"Wait," she says, peering closer and looping the video. "There. The starboard thrusters are firing. She must have fixed them!"`
-			`	She turns to you, hope glimmering in her eyes.`
-			`	"Captain, they might still be alive! Please... help me look for them."`
-				choice
-					`"That's not what you paid me for. We head back to <origin>."`
-					`"Are you sure?"`
-						goto agree
-					`"Of course. If there's any chance at all we'll find them."`
-						goto agree
 
-			
-			label sticktotheplan
-			`	Mera stares at you, her hand twitching near her weapon. For several long moments everything is still and then she seems to deflate.`
-			`	It's your ship, captain, she says dejectedly. If you're not brave enough to help I'll just need to find someone on <origin> who is.`
-				choice
-					`"That sounds like your best option."`
-						goto return
-					`"Well, okay then. I'll do it."`
-				
-			label agree
-			`	She nods once and looks back at her screen.`
-			`	"They would have come down somewhere around here," she says, indicating a point on the map which consists mostly of ocean. At least there won't be any locals around. Land on Cloudfire and I'll set up a search pattern."`
-			
-			label return
-			`	"If that's your decision I'll be in my cabin, Mera says, swishing past you on her way out."`
-			`	"A contract is a contract," you remind her as she goes, but she gives no indication of having heard you.`
-				set "refused rescue"
-	
+			label end # Do I need this to skip the unnecessary parts?
+
+		timer 600
+			on timeup
+				`	You remain far outside the combat zone to avoid getting caught by a stray explosion as Mera tags one ship after another, feeding the data into her recording gear with practiced ease. For the twentieth time you watch her scrolling down the list of ships, but then she seems to freeze and the fur on the back of her neck stands on end.`
+				`	Looking closer at the screen, you see that she has tagged a Shield Beetle which seems to be in trouble. Its starboard steering thruster is out and it is careening fast into the atmosphere of <destination>.`
+				`	"What's wrong?" You ask, but Mera doesn't seem to hear you. You both watch as the Shield Beetle is wreathed in plasma as it dives uncontrolled into the atmosphere.`
+				`	"No," Mera whispers, her voice like the mewl of a distressed kitten. "It can't have been, I must have made a mistake."`
+				`	"Mera," you say louder. "What's going on?"`
+				`	She looks in the direction of your voice but you get the impression that she doesn't really see you. She seems suddenly more child-like. Afraid.`
+				`	"It's..." She takes a breath and regains some control. "I think that was my mother's ship. Wait, I need to check. I have to be sure."`
+				`	Tweaking the controls with incredible precision, she brings up her recording and highlights the name of the crashed vessel. Mon e Loh.`
+				`	"It's a common enough ship name," she says. "Maybe it's not..."`
+				`	She scrolls back through the recording until she finds the last time that the Mon e Loh anti-missile turrets fired, looping a tenth of a second of footage in ultra slow motion.`
+				`	"It's her alright," she says, sounding resigned now. "I helped install an extra set of supercapacitors to keep the Bullfrogs firing."`
+				`	She scrolls forward once again, watching the final moments as the Mon e Loh starts to tumble.`
+				`	"Wait," she says, peering closer and looping the video. "There. The starboard thrusters are firing. She must have fixed them!"`
+				`	She turns to you, hope glimmering in her eyes.`
+				`	"Captain, they might still be alive! Please... help me look for them."`
+					choice
+						`"That's not what you're paying me for. We head back to <origin>."`
+						`"Are you sure?"`
+							goto agree
+						`"Of course. If there's any chance at all we'll find them."`
+							goto agree
+
+				`	Mera stares at you, her hand twitching near her weapon. For several long moments everything is still and then she seems to deflate.`
+				`	"It's your ship, captain," she says dejectedly. "If you're not brave enough to help I'll just need to find someone on <origin> who is."`
+					choice
+						`"That sounds like your best option."`
+							goto return
+						`"Well, okay then. I'll do it."`
+
+				label agree
+				`	She nods once and looks back at her screen.`
+				`	"They would have come down somewhere around here," she says, indicating a point on the map which consists mostly of ocean. At least there won't be any locals around. Land on Cloudfire and I'll set up a search pattern."`
+
+				label return
+				`	"If that's your decision I'll be in my cabin," Mera says, swishing past you on her way out.`
+				`	"A contract is a contract," you remind her as she goes, but she gives no indication of having heard you.`
+					set "refused rescue"
+
+	to complete
+		or
+			has "Unfettered Rescue: done"
+			"refused rescue" = 1
+
+	on visit
+		dialog
+			`You have landed back on <origin> after promising Mera that you would help to find the Mon e Loh, but you have not found the ship yet. Return to Cloudfire to search for survivors.`
+
 	on complete
 		conversation
 			branch refused
 				"refused rescue" = 1
-			
-			# Branch to fire when completing mission after completion of Unfettered Rescue.
-			
-			label refused
-			`	You land back on <origin>, and by the time you have finished your post-flight checklist Mera has gathered up her gear and is making her way out of the <ship>. She sees you watching her and turns away without a word.`
-			action
-				payment 50000 # Does this seem like a reasonable amount?
-				clear "refused rescue"
-			
+				`	You land back on <origin>, and by the time you have finished your post-flight checklist Mera has disconnected her gear and is making her way out of the <ship>. She sees you watching her and turns away without a word.`
+				action
+					payment 50000
+					outfit "value detector" -1
+					clear "refused rescue"
+			branch rescued
+				has "Unfettered Rescue: done"
+				# Branch to fire when completing mission after completion of Unfettered Rescue. In this branch Mera will let you keep the value detector and the captain of the Mon e Loh will give you something extra. I'll write this after the rescue mission.
+
+	npc accompany
+		government "Hai (Unfettered)" # I'll neeed to switch this to something neutral, I think.
+		personality landing
+		ship "Shield Beetle (Low crew)" "Mon e Loh"
+		system "Wah Ki"
+
 
 
 mission "Unfettered Rescue"
@@ -633,17 +654,19 @@ mission "Unfettered Rescue"
 			`	Mera directs you into a long, wide loop, skirting the section of ocean which she had earlier determined to be the most likely area for the Shield Beetle to have come down. The low hum of your engines is the only sound as you follow the course, and outside the clouds fade from bright white, through orange to a delicate pink.`
 			`	"Nothing so far," Mera grumbles, and you see that she is tightly gripping the sides of her display.`
 			choice
-				`	We'll keep looking. We'll find them.`
-				`	Maybe we should try a different strategy?`
+				`	"We'll keep looking. We'll find them."`
+				`	"Maybe we should try a different strategy?"`
 			`	Mera is silent but her grip loosens a little and then she looks up from her screen in thought.`
 			`	"We know they had propulsion," she muses, "so they wouldn't have just kept falling. They would aim for land."`
 			`	She pulls up the map again, this time examining the nearby islands, zooming in and out as she examines each in turn.`
 			`	"Somewhere with fresh water, no local population, and maybe a sheltered bay to splash down in."`
 			`	After a few moments she identifies one and passes the bearing over to your helm. You swing the <ship> around onto the new course, gun the engines, and soon you can see the island breaking up the horizon dead ahead. As you draw closer you see two peaks covered in greenery jutting out of the ocean, with a wide sand bank in the middle which probably splits the island in two at high tide.`
-			`	You circle the island, which looks idyllically picturesque in the dwindiling twilight, but there is no sign of the Mon e Loh.`
-
-
-
-
-
-# To-do; add Shield Beetle 'Mon e Loh' with extra Supercapacitors.
+			`	You circle the island, which looks idyllically picturesque in the dwindiling twilight, but there is no sign of the Mon e Loh. Mera's frustration is evident by the way she taps her claws against the side of her console, the rhythm getting erver quicker. Suddenly she stops.`
+			`	"They're hiding," she says, throwing her head back and spinning her chair in a full circle. "They don't want the Fettered to find them like this!"`
+			choice
+				`	"So how does this help us?"`
+				`	"Can we show them we're friendly somehow?"`
+			`	"It's simple," Mera tells you with a playful glint in her eye. "I'll just call my mom."`
+			`	She pulls out a standard communicator and taps it a few times.`
+			`	"What?" she asks you with a smirk. "You thought I was going to remodulate your shield matrix or spoof your IFF? Sometimes the simplest solutions are the best."`
+			`	Ten minutes later, after listening in to a surreal conversation in which Mera and her mother organized a rendezvous as though they were arranging to meet at a cozy tea house instead of an extraction from behind enemy lines, the <ship> was lands on the beach of the island you had circled earlier, while the Mon e Loh rises from the bay like a leviathan.`

--- a/data/hai/unfettered side missions.txt
+++ b/data/hai/unfettered side missions.txt
@@ -542,9 +542,9 @@ mission "Unfettered Sea Scorpion Shakedown"
 						decline
 
 			label okay
-			`	She literally jumps up and down on the spot and then turns to hustle towards the <ship>, calling over her shoulder, "I'll install the equipment as we go, it shouldn't be difficult."`
+			`	She does a quick shuffle which could be interpreted as a dance and then turns to hustle towards the <ship>, calling over her shoulder, "I'll install the equipment as we go, it shouldn't be difficult."`
 			accept
-			
+
 		log "People" "Mera" `An Unfettered engineer who is interested in ship designs of all kinds. She is easily excited by new technologies and ships, and seems to communicate partly through her body language.`
 
 	on enter Wah Ki
@@ -572,7 +572,7 @@ mission "Unfettered Sea Scorpion Shakedown"
 		timer 600
 			on timeup
 				`	You remain far outside the combat zone to avoid getting caught by a stray explosion as Mera tags one ship after another, feeding the data into her recording gear with practiced ease. For the twentieth time you watch her scrolling down the list of ships, but then she seems to freeze and the fur on the back of her neck stands on end.`
-				`	Looking closer at the screen, you see that she has tagged a Shield Beetle which seems to be in trouble. Its starboard steering thruster is out and it is careening fast into the atmosphere of <destination>.`
+				`	Looking closer at the screen, you see that she has tagged a Shield Beetle which seems to be in trouble. Its starboard steering thruster is out and it is careening fast into the atmosphere of Cloudfire.`
 				`	"What's wrong?" You ask, but Mera doesn't seem to hear you. You both watch as the Shield Beetle is wreathed in plasma as it dives uncontrolled into the atmosphere.`
 				`	"No," Mera whispers, her voice like the mewl of a distressed kitten. "It can't have been, I must have made a mistake."`
 				`	"Mera," you say louder. "What's going on?"`
@@ -661,7 +661,7 @@ mission "Unfettered Rescue"
 			`	She pulls up the map again, this time examining the nearby islands, zooming in and out as she examines each in turn.`
 			`	"Somewhere with fresh water, no local population, and maybe a sheltered bay to splash down in."`
 			`	After a few moments she identifies one and passes the bearing over to your helm. You swing the <ship> around onto the new course, gun the engines, and soon you can see the island breaking up the horizon dead ahead. As you draw closer you see two peaks covered in greenery jutting out of the ocean, with a wide sand bank in the middle which probably splits the island in two at high tide.`
-			`	You circle the island, which looks idyllically picturesque in the dwindiling twilight, but there is no sign of the Mon e Loh. Mera's frustration is evident by the way she taps her claws against the side of her console, the rhythm getting erver quicker. Suddenly she stops.`
+			`	You circle the island, which looks idyllically picturesque in the dwindiling twilight, but there is no sign of the Mon e Loh. Mera's frustration is evident by the way she taps her claws against the side of her console, the rhythm getting ever quicker. Suddenly she stops.`
 			`	"They're hiding," she says, throwing her head back and spinning her chair in a full circle. "They don't want the Fettered to find them like this!"`
 			choice
 				`	"So how does this help us?"`
@@ -669,4 +669,4 @@ mission "Unfettered Rescue"
 			`	"It's simple," Mera tells you with a playful glint in her eye. "I'll just call my mom."`
 			`	She pulls out a standard communicator and taps it a few times.`
 			`	"What?" she asks you with a smirk. "You thought I was going to remodulate your shield matrix or spoof your IFF? Sometimes the simplest solutions are the best."`
-			`	Ten minutes later, after listening in to a surreal conversation in which Mera and her mother organized a rendezvous as though they were arranging to meet at a cozy tea house instead of an extraction from behind enemy lines, the <ship> was lands on the beach of the island you had circled earlier, while the Mon e Loh rises from the bay like a leviathan.`
+			`	Ten minutes later, after listening in to a surreal conversation in which Mera and her mother organized a rendezvous as though they were arranging to meet at a cozy tea house instead of an extraction from behind enemy lines, the <ship> lands on the beach of the island you had circled earlier, while the Mon e Loh rises from the bay like a leviathan.`


### PR DESCRIPTION
Content (Missions)

## Acknowledgement

- [x ] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Two missions featuring Mera (which would perhaps make this the first meeting with her), a UHai engineer who is on the team working on the Sea Scorpions. She contracts FL to take her to Wah Ki to get data on Sea Scorpion performance in combat, but while there she observes her mother's shield beetle crash landing on Cloudfire. She asks FL to conduct a search-and-rescue mission, and if the request is accepted this leads into the second mission, in which we find the crashed ship, assist with repairs, and learn a little bit about why the UHai keep attacking this system.

Currently I have only written the first mission, and even for that I think the mission logic will need tweaked. In particular I think the way I have been trying to link the two missions will need to be changed. I wanted to write the first mission as a straight waypoint mission which completes on return to the origin, although that is the 'bad' ending because you have refused to help Mera, who is not at all impressed. If you do agree to help I wanted to fail the original mission and have the rescue mission trigger when landing on Cloudfire, as long as you have failed the first mission. Unfortunately this would mean that you would have no active mission from when you finish the conversation on entering Wah Ki until you land on Cloudfire, and I am also not sure if there is another way to fail the mission.
