### PR TITLE
Fix RequiredCrew logic for automatons

### DIFF
--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -3179,8 +3179,9 @@ double Ship::DragForce() const
 
 int Ship::RequiredCrew() const
 {
+	// Automatons require no crew but their outfits might.
 	if(attributes.Get("automaton"))
-		return 0;
+		return max<int>(0, attributes.Get("required crew"));
 
 	// Drones do not need crew, but all other ships need at least one.
 	return max<int>(1, attributes.Get("required crew"));


### PR DESCRIPTION
**Bug fix**
This PR addresses the bug described in issue #{12417}.

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
Update RequiredCrew method to correctly handle automatons with outfits which require crew. Instead of automatons returning 0 unconditionally, it now has 0 as the base crew and then checks crew requirements of outfits in exactly the same way as other ships do.

## Screenshots
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/d89798ab-6688-44f0-a564-0f67f5cb86e3" />
Automaton with no turret has crew requirement of 0.

<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/75dab5da-e8e8-461c-974d-0d3371132337" />
After the turret is installed, the minimum crew requirement of the automaton is now 1.
